### PR TITLE
SNMP monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1336,7 @@ dependencies = [
  "itertools",
  "keepcalm",
  "log",
+ "peg",
  "serde",
  "serde-aux",
  "serde-value",

--- a/crates/stylus-ui/web/src/Visuals.tsx
+++ b/crates/stylus-ui/web/src/Visuals.tsx
@@ -220,6 +220,12 @@ function StackVisualization({ stacks, statusData, size }: StackVisualizationProp
             if (parts.length === 3) {
                 return { groups: parts[0], columns: parts[1], rows: parts[2] };
             }
+            if (parts.length === 2) {
+                return { groups: 1, columns: parts[0], rows: parts[1] };
+            }
+            if (parts.length === 1) {
+                return { groups: 1, columns: parts[0], rows: 1 };
+            }
             return { groups: 1, columns: 1, rows: 1 };
         });
         return groupDefs;
@@ -256,17 +262,26 @@ function StackVisualization({ stacks, statusData, size }: StackVisualizationProp
                         childIndex++;
                         
                         if (child) {
+                            let title = `${child.id}`;
+                            for (const [key, value] of Object.entries(child.child.status.metadata)) {
+                                title += `\n${key}: ${value}`;
+                            }
                             groupChildren.push(
                                 <StatusIndicator 
                                     key={`${row}-${col}`}
                                     status={child.child.status.status} 
                                     className="stack-status-indicator"
-                                    title={child.id}
+                                    title={title}
                                 />
                             );
                         } else {
                             groupChildren.push(
-                                <div key={`${row}-${col}`} className="stack-cell-empty" title={`Empty slot ${childIndex}`} />
+                                <StatusIndicator 
+                                    key={`${row}-${col}`}
+                                    status="blank"
+                                    className="stack-status-indicator"
+                                    title={`No child found for port index ${childIndex}`}
+                                />
                             );
                         }
                     }

--- a/crates/stylus-ui/web/src/style.css
+++ b/crates/stylus-ui/web/src/style.css
@@ -28,7 +28,7 @@
   --base-status-success: #10b981;
   --base-status-timeout: #d7ea08;
   --base-status-error: #ef4444;
-  --base-status-blank: #9ca3af;
+  --base-status-blank: #b5cad3;
   
   /* Button colors */
   --base-text-button: white;

--- a/crates/stylus/Cargo.toml
+++ b/crates/stylus/Cargo.toml
@@ -38,3 +38,4 @@ clap = { version = "4.5", features = ["derive", "env"] }
 keepcalm = { version = "0.4.1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 include_directory = "0.1"
+peg = "0.8"

--- a/crates/stylus/README.md
+++ b/crates/stylus/README.md
@@ -94,6 +94,25 @@ set -xeuf -o pipefail
 curl --retry 2 --max-time 5 --connect-timeout 5 http://192.168.1.1:9000
 ```
 
+### SNMP
+
+**Stylus** has a built-in SNMP monitor that can be used to monitor network
+devices. 
+
+```yaml
+snmp:
+  id: router-{{ index }}
+  interval: 60s
+  timeout: 30s
+  exclude: |
+    ifType != 'ethernetCsmacd'
+  red: |
+    ifOperStatus == "up" and ifSpeed < 1000000000
+  target:
+    host: 192.168.1.254
+    community: public
+```
+
 ### Advanced techniques
 
 Tools such as `jq`, `sed`, or `awk` can be used for more advanced tests (ie:

--- a/crates/stylus/src/expressions.rs
+++ b/crates/stylus/src/expressions.rs
@@ -1,0 +1,305 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum Value {
+    Int(i64),
+    Str(String),
+}
+
+pub type Result = std::result::Result<Value, Error>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Error(String);
+
+impl std::fmt::Debug for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::Int(i) => write!(f, "{i:?}"),
+            Value::Str(s) => write!(f, "{s:?}"),
+        }
+    }
+}
+
+impl Value {
+    pub fn as_int(&self) -> i64 {
+        match self {
+            Value::Int(i) => *i,
+            Value::Str(s) => s.parse::<i64>().unwrap_or_default(),
+        }
+    }
+
+    pub fn as_str(&self) -> String {
+        match self {
+            Value::Int(i) => i.to_string(),
+            Value::Str(s) => s.clone(),
+        }
+    }
+
+    pub fn as_bool(&self) -> bool {
+        self.is_truthy()
+    }
+
+    fn from_bool(b: bool) -> Self {
+        Value::Int(if b { 1 } else { 0 })
+    }
+
+    fn is_truthy(&self) -> bool {
+        match self {
+            Value::Int(i) => *i != 0,
+            Value::Str(s) => !s.is_empty(),
+        }
+    }
+
+    fn logical_not(self) -> Value {
+        Value::from_bool(!self.is_truthy())
+    }
+
+    fn logical_and(self, other: Value) -> Value {
+        Value::from_bool(self.is_truthy() && other.is_truthy())
+    }
+
+    fn logical_or(self, other: Value) -> Value {
+        Value::from_bool(self.is_truthy() || other.is_truthy())
+    }
+
+    fn cmp(self, other: Value) -> Ordering {
+        match (self, other) {
+            (Value::Int(a), Value::Int(b)) => a.cmp(&b),
+            (Value::Str(a), Value::Str(b)) => a.cmp(&b),
+            (a, b) => a.as_int().cmp(&b.as_int()),
+        }
+    }
+
+    fn add(self, other: Value) -> Value {
+        match (self, other) {
+            (Value::Int(a), Value::Int(b)) => Value::Int(a + b),
+            (Value::Str(a), Value::Str(b)) => Value::Str(format!("{}{}", a, b)),
+            (a, b) => Value::Str(format!("{}{}", a.as_str(), b.as_str())),
+        }
+    }
+
+    fn sub(self, other: Value) -> Value {
+        Value::Int(self.as_int() - other.as_int())
+    }
+
+    fn mul(self, other: Value) -> Value {
+        Value::Int(self.as_int() * other.as_int())
+    }
+
+    fn div(self, other: Value) -> Value {
+        Value::Int(self.as_int() / other.as_int())
+    }
+
+    fn pow_val(self, other: Value) -> Value {
+        let a = self.as_int();
+        let b = other.as_int();
+        Value::Int(a.pow(b as u32))
+    }
+
+    fn negate(self) -> Value {
+        Value::Int(-self.as_int())
+    }
+}
+
+fn unescape_string(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next() {
+                Some('\\') => output.push('\\'),
+                Some('"') => output.push('"'),
+                Some('\'') => output.push('\''),
+                Some(other) => {
+                    output.push('\\');
+                    output.push(other);
+                }
+                None => output.push('\\'),
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+peg::parser!( pub grammar expression() for str {
+    rule number() -> i64
+        = n:$(['0'..='9']+) { n.parse().unwrap() }
+
+    rule string() -> String
+        = r#"""# s:$( ( r#"\""# / r#"\\"# / r#"\'"# / (!r#"""# [_]) )* ) r#"""# { unescape_string(s) }
+        / r#"'"# s:$( ( r#"\""# / r#"\\"# / r#"\'"# / (!r#"'"# [_]) )* ) r#"'"# { unescape_string(s) }
+
+    rule ident() -> String
+        = i:$([ 'a'..='z' | 'A'..='Z' | '_' ][ 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' ]*) { i.to_string() }
+
+    rule ws() = quiet!{[ ' ' | '\t' | '\r' | '\n' ]*}
+
+    pub rule calculate(ctx: &HashMap<String, Value>) -> Result
+        = ws() v:expr(ctx) ws() { v }
+
+    rule expr(ctx: &HashMap<String, Value>) -> Result = precedence!{
+        // Python-like precedence (low -> high): or, and, not, comparisons, +-, */, ^, atoms
+        x:(@) ws() "or" ws() y:@ { Ok(x?.logical_or(y?)) }
+        x:(@) ws() "and" ws() y:@ { Ok(x?.logical_and(y?)) }
+              ws() "not" ws() v:@ { Ok(v?.logical_not()) }
+        --
+        x:(@) ws() ">=" ws() y:@ { Ok(Value::from_bool(x?.cmp(y?) >= Ordering::Equal)) }
+        x:(@) ws() "<=" ws() y:@ { Ok(Value::from_bool(x?.cmp(y?) <= Ordering::Equal)) }
+        x:(@) ws() "==" ws() y:@ { Ok(Value::from_bool(x?.cmp(y?) == Ordering::Equal)) }
+        x:(@) ws() "!=" ws() y:@ { Ok(Value::from_bool(x?.cmp(y?) != Ordering::Equal)) }
+        x:(@) ws() ">" ws() y:@ { Ok(Value::from_bool(x?.cmp(y?) == Ordering::Greater)) }
+        x:(@) ws() "<" ws() y:@ { Ok(Value::from_bool(x?.cmp(y?) == Ordering::Less)) }
+        --
+        x:(@) ws() "+" ws() y:@ { Ok(x?.add(y?)) }
+        x:(@) ws() "-" ws() y:@ { Ok(x?.sub(y?)) }
+              ws() "-" ws() v:@ { Ok(v?.negate()) }
+        --
+        x:(@) ws() "*" ws() y:@ { Ok(x?.mul(y?)) }
+        x:(@) ws() "/" ws() y:@ { Ok(x?.div(y?)) }
+        --
+        x:@   ws() "^" ws() y:(@) { Ok(x?.pow_val(y?)) }
+        --
+        ws() "str" ws() "(" ws() v:expr(ctx) ws() ")" { Ok(Value::Str(v?.as_str())) }
+        ws() "int" ws() "(" ws() v:expr(ctx) ws() ")" { Ok(Value::Int(v?.as_int())) }
+        ws() "(" ws() v:expr(ctx) ws() ")" { Ok(v?) }
+        ws() s:string() { Ok(Value::Str(s)) }
+        ws() n:number() { Ok(Value::Int(n)) }
+        ws() "startswith" ws() "(" ws() a:expr(ctx) ws() "," ws() b:expr(ctx) ws() ")" {
+            let s1 = a?.as_str();
+            let s2 = b?.as_str();
+            Ok(Value::from_bool(s1.starts_with(&s2)))
+        }
+        ws() "endswith" ws() "(" ws() a:expr(ctx) ws() "," ws() b:expr(ctx) ws() ")" {
+            let s1 = a?.as_str();
+            let s2 = b?.as_str();
+            Ok(Value::from_bool(s1.ends_with(&s2)))
+        }
+        ws() "contains" ws() "(" ws() a:expr(ctx) ws() "," ws() b:expr(ctx) ws() ")" {
+            let s1 = a?.as_str();
+            let s2 = b?.as_str();
+            Ok(Value::from_bool(s1.contains(&s2)))
+        }
+        ws() "length" ws() "(" ws() v:expr(ctx) ws() ")" {
+            let s = v?.as_str();
+            Ok(Value::Int(s.len() as i64))
+        }
+        ws() "true" { Ok(Value::from_bool(true)) }
+        ws() "false" { Ok(Value::from_bool(false)) }
+        ws() id:ident() { match ctx.get(&id) { Some(v) => Ok(v.clone()), None => Err(Error(format!("unknown identifier: {}", id))) } }
+    }
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expression_with_context() {
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert("a".into(), Value::Int(2));
+        ctx.insert("b".into(), Value::Int(3));
+        ctx.insert("s".into(), Value::Str("x".into()));
+
+        // 2 + 3 == 5 => 1
+        let v = expression::calculate("a + b == 5", &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Int(1));
+
+        // logical and/or and prefix not (Python-like truthiness)
+        let v = expression::calculate("(a and b) or not 0", &ctx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, Value::Int(1));
+
+        // string concat
+        let v = expression::calculate("s + \"y\"", &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Str("xy".into()));
+    }
+
+    #[test]
+    fn test_precedence_python_like() {
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert("a".into(), Value::Int(1));
+        ctx.insert("b".into(), Value::Int(2));
+        ctx.insert("c".into(), Value::Int(3));
+
+        // and/or lower precedence than comparisons
+        let v = expression::calculate("a == 1 and b == 2 or c == 0", &ctx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, Value::Int(1)); // (a==1 and b==2) or (c==0)
+
+        let v = expression::calculate("a == 0 and b == 2 or c == 3", &ctx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, Value::Int(1)); // (a==0 and b==2) or (c==3)
+
+        // not binds tighter than and/or but looser than comparisons
+        let v = expression::calculate("not a == 1", &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Int(0)); // not (a==1)
+
+        let v = expression::calculate("not a == 0 and b == 2", &ctx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, Value::Int(1)); // (not (a==0)) and (b==2)
+    }
+
+    #[test]
+    fn test_coercions() {
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert("n".into(), Value::Int(42));
+        ctx.insert("t".into(), Value::Str("7".into()));
+
+        let v = expression::calculate("str(n)", &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Str("42".into()));
+
+        let v = expression::calculate("int(t) + 1", &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Int(8));
+
+        let v = expression::calculate("str( int(\"5\") + 1 )", &ctx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, Value::Str("6".into()));
+    }
+
+    #[test]
+    fn test_string_quotes_and_escapes() {
+        let ctx: HashMap<String, Value> = HashMap::new();
+
+        let v = expression::calculate(r#"'a' + "b""#, &ctx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, Value::Str("ab".into()));
+
+        let v = expression::calculate(r#" '\"' "#, &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Str('"'.into()));
+
+        let v = expression::calculate(r#" '\'' "#, &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Str("'".into()));
+
+        let v = expression::calculate(r#" '\\' "#, &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Str(r"\".into()));
+
+        let v = expression::calculate(r#" "\\" "#, &ctx).unwrap().unwrap();
+        assert_eq!(v, Value::Str(r"\".into()));
+    }
+
+    #[test]
+    fn test_nested_expressions() {
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert("ifDescr".into(), Value::Str("eth0".into()));
+        let v = expression::calculate(
+            r#"
+        (startswith(ifDescr, 'eth') and not contains(ifDescr, '.'))
+          or contains(ifDescr, "10G Ethernet Adapter")
+          or contains(ifDescr, "2.5GbE Controller")
+          "#,
+            &ctx,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(v, Value::Int(1));
+    }
+}

--- a/crates/stylus/src/main.rs
+++ b/crates/stylus/src/main.rs
@@ -7,9 +7,11 @@ use keepcalm::SharedMut;
 
 mod config;
 mod css;
+mod expressions;
 mod http;
 mod interpolate;
 mod monitor;
+mod monitors;
 mod status;
 mod worker;
 
@@ -70,8 +72,7 @@ async fn run() {
                     println!("Monitor Log");
                     println!("-----------");
                     println!();
-
-                    monitor_run(monitor, &mut |_, msg| {
+                    monitor_run(&monitor, &mut |_, msg| {
                         state
                             .process_message(&monitor.id, msg, &config.css.metadata, &mut |m| {
                                 println!("{}", m);

--- a/crates/stylus/src/monitors/mod.rs
+++ b/crates/stylus/src/monitors/mod.rs
@@ -1,0 +1,1 @@
+pub mod snmp;

--- a/crates/stylus/src/monitors/snmp.rs
+++ b/crates/stylus/src/monitors/snmp.rs
@@ -84,10 +84,8 @@ impl SnmpNetworkMonitorConfig {
         // Auth (v1/v2c vs v3)
         match self.target.version {
             1 | 2 => {
-                if let Some(ref community) = self.target.community {
-                    parts.push("-c".into());
-                    parts.push(community.clone());
-                }
+                parts.push("-c".into());
+                parts.push(self.target.community.clone());
             }
             3 => {
                 if let Some(ref username) = self.target.username {
@@ -171,7 +169,8 @@ pub struct SnmpNetworkMonitorSnmpConfig {
     pub port: Option<u16>,
     #[serde(default = "default_version")]
     pub version: u8,
-    pub community: Option<String>,
+    #[serde(default = "default_community")]
+    pub community: String,
     pub username: Option<String>,
     pub auth_protocol: Option<String>,
     pub auth_password: Option<String>,
@@ -179,6 +178,10 @@ pub struct SnmpNetworkMonitorSnmpConfig {
     pub privacy_password: Option<String>,
     #[serde(default = "default_bulk")]
     pub bulk: bool,
+}
+
+fn default_community() -> String {
+    "public".to_string()
 }
 
 fn default_version() -> u8 {

--- a/crates/stylus/src/monitors/snmp.rs
+++ b/crates/stylus/src/monitors/snmp.rs
@@ -1,0 +1,319 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::{MonitorDirAxisValue, MonitorDirChildConfig, MonitorDirTestConfig},
+    expressions::{self, Value},
+    interpolate::interpolate_id,
+    monitor::{MonitorMessageProcessor, MonitorMessageProcessorInstance},
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub struct SnmpNetworkMonitorConfig {
+    target: SnmpNetworkMonitorSnmpConfig,
+    pub id: String,
+    #[serde(with = "humantime_serde")]
+    pub interval: Duration,
+    #[serde(with = "humantime_serde")]
+    pub timeout: Duration,
+    #[serde(default = "default_include")]
+    pub include: String,
+    #[serde(default = "default_exclude")]
+    pub exclude: String,
+    #[serde(default = "default_red")]
+    pub red: String,
+    #[serde(default = "default_green")]
+    pub green: String,
+    #[serde(skip_deserializing)]
+    pub children: BTreeMap<String, MonitorDirChildConfig>,
+    #[serde(skip_deserializing)]
+    pub test: Option<MonitorDirTestConfig>,
+}
+
+fn default_include() -> String {
+    format!("true")
+}
+
+fn default_exclude() -> String {
+    format!("false")
+}
+
+fn default_red() -> String {
+    format!("false")
+}
+
+fn default_green() -> String {
+    format!("ifOperStatus == 'up' and ifAdminStatus == 'up'")
+}
+
+impl SnmpNetworkMonitorConfig {
+    pub fn test(&self) -> MonitorDirTestConfig {
+        let binary = if self.target.bulk {
+            "snmpbulkwalk"
+        } else {
+            "snmpwalk"
+        };
+
+        let mut parts: Vec<String> = vec![binary.to_string()];
+
+        // Output formatting: -O sQ
+        parts.push("-OsQ".into());
+
+        // Timeout (seconds)
+        parts.push("-t".into());
+        parts.push(self.timeout.as_secs().to_string());
+
+        // SNMP version
+        let version_flag = match self.target.version {
+            1 => "1",
+            2 => "2c",
+            3 => "3",
+            _ => "2c",
+        };
+        parts.push("-v".into());
+        parts.push(version_flag.to_string());
+
+        // Auth (v1/v2c vs v3)
+        match self.target.version {
+            1 | 2 => {
+                if let Some(ref community) = self.target.community {
+                    parts.push("-c".into());
+                    parts.push(community.clone());
+                }
+            }
+            3 => {
+                if let Some(ref username) = self.target.username {
+                    parts.push("-u".into());
+                    parts.push(username.into());
+                }
+
+                let has_auth =
+                    self.target.auth_protocol.is_some() && self.target.auth_password.is_some();
+                let has_priv = self.target.privacy_protocol.is_some()
+                    && self.target.privacy_password.is_some();
+
+                let level = if has_priv {
+                    "authPriv"
+                } else if has_auth {
+                    "authNoPriv"
+                } else {
+                    "noAuthNoPriv"
+                };
+                parts.push("-l".into());
+                parts.push(level.to_string());
+
+                if has_auth {
+                    parts.push("-a".into());
+                    parts.push(self.target.auth_protocol.as_ref().unwrap().to_uppercase());
+                    parts.push("-A".into());
+                    parts.push({
+                        let input: &str = self.target.auth_password.as_ref().unwrap();
+                        input.into()
+                    });
+                }
+                if has_priv {
+                    parts.push("-x".into());
+                    parts.push(
+                        self.target
+                            .privacy_protocol
+                            .as_ref()
+                            .unwrap()
+                            .to_uppercase(),
+                    );
+                    parts.push("-X".into());
+                    parts.push({
+                        let input: &str = self.target.privacy_password.as_ref().unwrap();
+                        input.into()
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        // Agent (host:port)
+        if let Some(port) = self.target.port {
+            parts.push(format!("{}:{}", self.target.host, port));
+        } else {
+            parts.push(self.target.host.clone());
+        }
+
+        parts.push("ifTable".into());
+
+        MonitorDirTestConfig {
+            interval: self.interval,
+            timeout: self.timeout,
+            command: PathBuf::from("/usr/bin/env"),
+            args: parts,
+            processor: Some(Arc::new(SnmpMonitorMessageProcessor {
+                id: self.id.clone(),
+                include: self.include.clone(),
+                exclude: self.exclude.clone(),
+                red: self.red.clone(),
+                green: self.green.clone(),
+            })),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub struct SnmpNetworkMonitorSnmpConfig {
+    pub host: String,
+    pub port: Option<u16>,
+    #[serde(default = "default_version")]
+    pub version: u8,
+    pub community: Option<String>,
+    pub username: Option<String>,
+    pub auth_protocol: Option<String>,
+    pub auth_password: Option<String>,
+    pub privacy_protocol: Option<String>,
+    pub privacy_password: Option<String>,
+    #[serde(default = "default_bulk")]
+    pub bulk: bool,
+}
+
+fn default_version() -> u8 {
+    2
+}
+
+fn default_bulk() -> bool {
+    true
+}
+
+#[derive(Debug)]
+pub struct SnmpMonitorMessageProcessor {
+    id: String,
+    include: String,
+    exclude: String,
+    red: String,
+    green: String,
+}
+
+#[derive(Debug, Default)]
+pub struct SnmpMonitorMessageProcessorInstance {
+    id: String,
+    include: String,
+    exclude: String,
+    red: String,
+    green: String,
+    ports: Mutex<HashMap<usize, HashMap<String, Value>>>,
+}
+
+impl MonitorMessageProcessor for SnmpMonitorMessageProcessor {
+    fn new(&self) -> Box<dyn MonitorMessageProcessorInstance> {
+        Box::new(SnmpMonitorMessageProcessorInstance {
+            id: self.id.clone(),
+            include: self.include.clone(),
+            exclude: self.exclude.clone(),
+            red: self.red.clone(),
+            green: self.green.clone(),
+            ports: Default::default(),
+        })
+    }
+}
+
+impl MonitorMessageProcessorInstance for SnmpMonitorMessageProcessorInstance {
+    fn process_message(&self, input: &str) -> Vec<String> {
+        // Parse the input as <oid>.index = <valud>?
+        // Note that value may be missing and input may end in the equals. This is considered an empty string.
+
+        if let Some((left, right)) = input.split_once("=") {
+            let left = left.trim();
+            let right = right.trim();
+
+            if let Some((oid, index)) = left.rsplit_once(".") {
+                let oid = oid.trim();
+                if let Ok(index) = index.parse::<usize>() {
+                    let v = if let Ok(v) = right.parse::<i64>() {
+                        Value::Int(v)
+                    } else {
+                        Value::Str(right.to_string())
+                    };
+                    self.ports
+                        .lock()
+                        .unwrap()
+                        .entry(index)
+                        .or_default()
+                        .insert(oid.to_string(), v);
+                    return vec![];
+                }
+            }
+        };
+
+        log::warn!("Unexpected snmpwalk/snmpbulkwalk output: {}", input);
+        vec![]
+    }
+
+    fn finalize(&self) -> Vec<String> {
+        let mut result = vec![];
+
+        for (port_index, port_metadata) in std::mem::take(&mut *self.ports.lock().unwrap()) {
+            let include = calculate_bool(&self.include, &port_metadata);
+            if !include {
+                continue;
+            }
+
+            let exclude = calculate_bool(&self.exclude, &port_metadata);
+            if exclude {
+                continue;
+            }
+
+            let red = calculate_bool(&self.red, &port_metadata);
+            let green = calculate_bool(&self.green, &port_metadata);
+
+            let mut values = BTreeMap::new();
+            values.insert(
+                "index".into(),
+                MonitorDirAxisValue::Number(port_index as i64),
+            );
+            let Ok(port_id) = interpolate_id(&values, &self.id) else {
+                log::warn!(
+                    "Failed to interpolate id for port {}: {:?}",
+                    port_index,
+                    values
+                );
+                continue;
+            };
+
+            for (oid, value) in port_metadata {
+                result.push(format!(
+                    "group.{}.status.metadata.{}={:?}",
+                    port_id,
+                    oid,
+                    value.as_str()
+                ));
+            }
+
+            if red {
+                result.push(format!("group.{}.status.status=\"red\"", port_id));
+            } else if green {
+                result.push(format!("group.{}.status.status=\"green\"", port_id));
+            }
+        }
+
+        result
+    }
+}
+
+fn calculate_bool(expression: &str, metadata: &HashMap<String, Value>) -> bool {
+    match expressions::expression::calculate(expression, metadata) {
+        Ok(Ok(value)) => value.as_bool(),
+        Err(e) => {
+            log::warn!("Failed to parse expression {:?}: {}", expression, e);
+            false
+        }
+        Ok(Err(e)) => {
+            log::warn!("Failed to evaluate expression {:?}: {:?}", expression, e);
+            false
+        }
+    }
+}

--- a/crates/stylus/src/status.rs
+++ b/crates/stylus/src/status.rs
@@ -36,7 +36,7 @@ pub struct MonitorState {
     pub children: BTreeMap<String, MonitorChildStatus>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct MonitorChildStatus {
     pub axes: BTreeMap<String, MonitorDirAxisValue>,
 
@@ -124,6 +124,7 @@ impl MonitorState {
                     LogStream::StdOut => "stdout",
                     LogStream::StdErr => "stderr",
                 };
+
                 // TODO: Long lines without \n at the end should have some sort of other delimiter inserted
                 self.process_log_message(stream, m.trim_end(), direct_logger);
             }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,6 +21,7 @@
     - [Standard Monitor](configuration/monitor/standard.md)
     - [Group Monitor](configuration/monitor/group.md)
     - [SNMP Monitor](configuration/monitor/snmp.md)
+- [Expression Language](configuration/expressions.md)
 - [Advanced Configuration](configuration/advanced.md)
 
 # Examples and Tips

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,9 @@
 - [Server Configuration](configuration/server/README.md)
     - [CSS Configuration](configuration/css/README.md)
 - [Monitor Configuration](configuration/monitor/README.md)
+    - [Standard Monitor](configuration/monitor/standard.md)
+    - [Group Monitor](configuration/monitor/group.md)
+    - [SNMP Monitor](configuration/monitor/snmp.md)
 - [Advanced Configuration](configuration/advanced.md)
 
 # Examples and Tips

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -1,45 +1,5 @@
 # Advanced Configuration
 
-## Group Monitors
-
-A group monitor allows a single test script's execution to update the state for
-multiple entities. For example, you may be able to scrape the state of multiple
-hosts from a single controller, or you may want to monitor the state of multiple
-ports on a single switch.
-
-```yaml
-group:
-    # The ID pattern for this group. This ID must use interpolation from axis values to generate a set of
-    # globally unique IDs. 
-    id: port-{{ index }}
-
-    # The configuration axes.
-    axes:
-        # The Axis name and a list of values
-        - name: index
-          values: [0, 1, 2, 3, 4, 5, 6, 7]
-
-    # A standard monitor configuration (see the Standard Monitor description)
-    test:
-        interval: 60s
-        timeout: 30s
-        command: test.sh
-```
-
-The group's test script is unique in that it must output state-modifying commands to its standard output. Each
-of these state-modifying commands starts with the prefix `@@STYLUS@@`.
-
-```bash
-echo '@@STYLUS@@ group.port-0.status.status="yellow"'
-echo '@@STYLUS@@ group.port-1.status.status="green"'
-echo '@@STYLUS@@ group.port-2.status.status="yellow"'
-echo '@@STYLUS@@ group.port-3.status.status="green"'
-echo '@@STYLUS@@ group.port-4.status.status="green"'
-echo '@@STYLUS@@ group.port-5.status.status="yellow"'
-echo '@@STYLUS@@ group.port-6.status.status="yellow"'
-echo '@@STYLUS@@ group.port-7.status.status="red"'
-```
-
 ## Metadata
 
 A test script may update metadata for the monitor, including the built-in status and description fields. These commands start with the prefix `@@STYLUS@@` and may be output to standard output or standard error.

--- a/docs/src/configuration/expressions.md
+++ b/docs/src/configuration/expressions.md
@@ -1,0 +1,205 @@
+# Expression Language
+
+Stylus uses a custom expression language for evaluating conditions in monitor configurations. This language supports arithmetic operations, logical operations, string manipulation, and comparisons.
+
+## Overview
+
+The expression language is currently only used in the SNMP monitor `include`,
+`exclude`, `red`, and `green` conditions
+
+## Data Types
+
+The expression language supports two main data types:
+
+- Integers: Whole numbers (e.g., `42`, `-17`, `0`)
+- Strings: Text values enclosed in quotes (e.g., `"hello"`, `'world'`)
+
+## Literals
+
+### Numbers
+```javascript
+42        // Positive integer
+-17       // Negative integer
+0         // Zero
+```
+
+### Strings
+Strings can be enclosed in single or double quotes:
+```javascript
+"hello world"    // Double quotes
+'hello world'    // Single quotes
+```
+
+### Escape Sequences
+Strings support escape sequences:
+```javascript
+"hello \"world\""    // Escaped double quote
+'hello \'world\''    // Escaped single quote
+"hello \\world\\"    // Escaped backslash
+```
+
+### Boolean Values
+```javascript
+true      // Boolean true (evaluates to 1)
+false     // Boolean false (evaluates to 0)
+```
+
+## Arithmetic Operations
+
+### Basic Arithmetic
+```javascript
+a + b     // Addition (numbers) or concatenation (strings)
+a - b     // Subtraction
+a * b     // Multiplication
+a / b     // Division
+a ^ b     // Exponentiation (a raised to power b)
+-a        // Negation
+```
+
+### Examples
+```javascript
+2 + 3           // 5
+"hello" + " " + "world"    // "hello world"
+10 - 3          // 7
+4 * 5           // 20
+15 / 3          // 5
+2 ^ 3           // 8
+-5              // -5
+```
+
+## Comparison Operations
+
+### Comparison Operators
+```javascript
+a == b    // Equal to
+a != b    // Not equal to
+a > b     // Greater than
+a < b     // Less than
+a >= b    // Greater than or equal to
+a <= b    // Less than or equal to
+```
+
+### Examples
+```javascript
+5 == 5           // true
+"up" == "down"   // false
+10 > 5           // true
+"abc" < "def"    // true
+7 >= 7           // true
+3 <= 10          // true
+```
+
+## Logical Operations
+
+### Logical Operators
+```javascript
+a and b   // Logical AND
+a or b    // Logical OR
+not a     // Logical NOT
+```
+
+### Examples
+```javascript
+true and true    // true
+true and false   // false
+true or false    // true
+false or false   // false
+not true         // false
+not false        // true
+```
+
+## String Functions
+
+### String Manipulation
+```javascript
+startswith(str, prefix)    // Check if string starts with prefix
+endswith(str, suffix)      // Check if string ends with suffix
+contains(str, substr)      // Check if string contains substring
+length(str)                // Get string length
+```
+
+### Examples
+```javascript
+startswith("hello world", "hello")    // true
+endswith("hello world", "world")      // true
+contains("hello world", "lo wo")      // true
+length("hello")                       // 5
+```
+
+## Type Conversion Functions
+
+### Type Conversion
+```javascript
+str(value)    // Convert value to string
+int(value)    // Convert value to integer
+```
+
+### Examples
+```javascript
+str(42)       // "42"
+int("123")    // 123
+str(true)     // "1"
+int("abc")    // 0 (default for failed conversion)
+```
+
+## Precedence and Associativity
+
+The expression language follows Python-like precedence rules (from lowest to highest):
+
+1. `or`
+2. `and`
+3. `not`
+4. Comparisons (`==`, `!=`, `>`, `<`, `>=`, `<=`)
+5. Addition/Subtraction (`+`, `-`)
+6. Multiplication/Division (`*`, `/`)
+7. Exponentiation (`^`)
+8. Functions, parentheses, literals, variables
+
+### Examples
+```javascript
+a == 1 and b == 2 or c == 0    // ((a == 1) and (b == 2)) or (c == 0)
+not a == 1                      // not (a == 1)
+2 + 3 * 4                       // 2 + (3 * 4) = 14
+2 ^ 3 + 1                       // (2 ^ 3) + 1 = 9
+```
+
+## Truthiness
+
+Values are considered "truthy" or "falsy" in logical operations:
+
+- Falsy values: `0`, `""` (empty string), `false`
+- Truthy values: Any non-zero number, any non-empty string, `true`
+
+### Examples
+
+```javascript
+0 and "hello"      // false (0 is falsy)
+1 and "hello"      // true (both are truthy)
+"" or 42           // true (42 is truthy)
+not 0              // true
+not "hello"        // false
+```
+
+## Context Variables
+
+Depending on the context, the expression language has access to different
+local variables.
+
+### SNMP Examples
+
+The [SNMP monitor](monitor/snmp.md) makes the OIDs for each interface available
+as context variables.
+
+```javascript
+// Check if interface is up and admin enabled
+ifOperStatus == "up" and ifAdminStatus == "up"
+
+// Check if interface is Ethernet and not loopback
+ifType == "ethernetCsmacd" and not contains(ifDescr, "Loopback")
+
+// Check if interface speed is less than 1Gbps
+ifSpeed < 1000000000
+
+// Check if interface description contains specific text
+contains(ifDescr, "10G Ethernet Adapter")
+```

--- a/docs/src/configuration/monitor/README.md
+++ b/docs/src/configuration/monitor/README.md
@@ -2,22 +2,13 @@
 
 Monitor configurations define how **Stylus** tests your infrastructure components. Each monitor consists of a test script that runs on a schedule and reports the status back to **Stylus**.
 
-## Standard Monitor
+## Monitor Types
 
-A standard monitor consists of a single test for a single host.
+Stylus supports several types of monitors:
 
-```yaml
-test:
-  # (optional) The internal ID to use for this test. If omitted, the ID is inferred from the monitor directory's name.
-  id: foo
-  # How often the test is run. The interval restarts from the last success or failure of the test.
-  interval: 60s
-  # How long the script will be given to run before it is killed.
-  timeout: 30s
-  # The test command to run, relative to the monitor directory. The PATH is not used and the file must be
-  # directly executable.
-  command: test.sh
-```
+- **[Standard Monitor](standard.md)** - Single test for a single host
+- **[Group Monitor](group.md)** - Single script that updates multiple monitors
+- **[SNMP Monitor](snmp.md)** - Network device monitoring via SNMP
 
 ## Logging
 
@@ -32,10 +23,6 @@ The state of a monitor is determined by the return value of the test script.
 - Yellow: A test that has timed out
 - Red: Tests that fail by returning a value other than zero
 - Green: Tests that return zero (success)
-
-## Group Monitors
-
-A group may be configured such that a single script may update states for multiple monitors. See [Advanced Configuration](../advanced.md) for examples of configuring such a group monitor.
 
 ## Metadata
 

--- a/docs/src/configuration/monitor/group.md
+++ b/docs/src/configuration/monitor/group.md
@@ -1,0 +1,89 @@
+# Group Monitor
+
+A group monitor allows a single test script's execution to update the state for
+multiple entities. For example, you may be able to scrape the state of multiple
+hosts from a single controller, or you may want to monitor the state of multiple
+ports on a single switch.
+
+## Configuration
+
+```yaml
+group:
+    # The ID pattern for this group. This ID must use interpolation from axis values to generate a set of
+    # globally unique IDs. 
+    id: port-{{ index }}
+
+    # The configuration axes.
+    axes:
+        # The Axis name and a list of values
+        - name: index
+          values: [0, 1, 2, 3, 4, 5, 6, 7]
+
+    # A standard monitor configuration (see the Standard Monitor description)
+    test:
+        interval: 60s
+        timeout: 30s
+        command: test.sh
+```
+
+## State Output
+
+The group's test script is unique in that it must output state-modifying commands to its standard output. Each
+of these state-modifying commands starts with the prefix `@@STYLUS@@`.
+
+```bash
+echo '@@STYLUS@@ group.port-0.status.status="yellow"'
+echo '@@STYLUS@@ group.port-1.status.status="green"'
+echo '@@STYLUS@@ group.port-2.status.status="yellow"'
+echo '@@STYLUS@@ group.port-3.status.status="green"'
+echo '@@STYLUS@@ group.port-4.status.status="green"'
+echo '@@STYLUS@@ group.port-5.status.status="yellow"'
+echo '@@STYLUS@@ group.port-6.status.status="yellow"'
+echo '@@STYLUS@@ group.port-7.status.status="red"'
+```
+
+## Example
+
+Here's a complete example of a group monitor that checks the status of multiple network ports:
+
+```yaml
+group:
+    id: port-{{ index }}
+    axes:
+        - name: index
+          values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+    test:
+        interval: 10s
+        timeout: 30s
+        command: test.sh
+```
+
+With a corresponding `test.sh` script:
+
+```bash
+#!/bin/bash
+set -xeuf -o pipefail
+echo '@@STYLUS@@ group.port-0.status.status="yellow"'
+echo '@@STYLUS@@ group.port-1.status.status="green"'
+echo '@@STYLUS@@ group.port-2.status.status="yellow"'
+echo '@@STYLUS@@ group.port-3.status.status="green"'
+echo '@@STYLUS@@ group.port-4.status.status="green"'
+echo '@@STYLUS@@ group.port-5.status.status="yellow"'
+echo '@@STYLUS@@ group.port-6.status.status="yellow"'
+if [ $((RANDOM % 2)) -eq 0 ]; then
+    echo '@@STYLUS@@ group.port-7.status.status="red"'
+else
+    echo '@@STYLUS@@ group.port-7.status.status="green"'
+fi
+```
+
+## Metadata
+
+Group monitors can also set metadata for each individual monitor using the same `@@STYLUS@@` prefix:
+
+```bash
+echo '@@STYLUS@@ group.port-0.status.description="Port 0 is experiencing high latency"'
+echo '@@STYLUS@@ group.port-0.status.metadata.latency="150ms"'
+echo '@@STYLUS@@ group.port-1.status.description="Port 1 is healthy"'
+echo '@@STYLUS@@ group.port-1.status.metadata.latency="5ms"'
+```

--- a/docs/src/configuration/monitor/snmp.md
+++ b/docs/src/configuration/monitor/snmp.md
@@ -1,52 +1,116 @@
 # SNMP Monitor
 
-SNMP monitors allow you to monitor network devices using the Simple Network Management Protocol (SNMP). This is particularly useful for monitoring switches, routers, and other network infrastructure.
+If you want to monitor network devices, you can often use
+[SNMP](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) to
+extract information from the device. SNMP allows you to query the device for
+information about its status using OIDs (Object Identifiers), which are roughly
+standardized across different devices.
+
+This is particularly useful for monitoring switches, routers, and other network
+infrastructure.
+
+See the manual for your networking device for the appropriate OIDs to use, or
+reference one of the following resources: 
+
+ - <https://ldapwiki.com/wiki/Wiki.jsp?page=SNMP>
+ - <https://networklessons.com/cisco/ccie-routing-switching/introduction-to-snmp>
 
 The SNMP monitor works like a [group monitor](group.md), but it uses SNMP to
 query the network device and create children for each detected interface.
 
+## Requirements
+
+The SNMP monitor requires the `snmpwalk` or `snmpbulkwalk` command to be
+installed on the system. These are typically available in the `net-snmp`
+package.
+
 ## Configuration
+
+Interfaces are first filtered by the `include` and `exclude` conditions. If
+`include` is true and `exclude` is false, the interface is included in the
+monitor.
+
+The `red` and `green` conditions are evaluated using the
+[expressions](../expressions.md) language.
+
+`red` is first evaluated. If it is true, the monitor will show red. Otherwise,
+`green` is evaluated. If it is true, the monitor will show green. If neither is
+true, the monitor will show blank.
+
+By default, the SNMP monitor will show interfaces as green if they have
+`ifOperStatus` and `ifAdminStatus` set to `"up"`, and blank if either of those
+is not `"up"`.
 
 ```yaml
 snmp:
-  # The ID pattern for this monitor. Uses interpolation from axis values.
+  # The ID pattern for this monitor. Uses interpolation from interface index.
   id: router-{{ index }}
-  
+
   # How often the SNMP queries are performed
   interval: 60s
-  
+
   # How long to wait for SNMP responses
   timeout: 30s
-  
-  # (optional) Filter to exclude certain interfaces or components
+
+  # (optional) Filter to include certain interfaces (default: "true")
+  include: |
+    ifType == 'ethernetCsmacd'
+
+  # (optional) Filter to exclude certain interfaces (default: "false")
   exclude: |
-    ifType != 'ethernetCsmacd'
-  
-  # (optional) Condition that determines when the monitor should be red
+    contains(ifDescr, 'Loopback')
+
+  # (optional) Condition that determines when the monitor should be red (default: "false")
   red: |
     ifOperStatus == "up" and ifSpeed < 1000000000
-  
+
+  # (optional) Condition that determines when the monitor should be green (default: "ifOperStatus == 'up' and ifAdminStatus == 'up'")
+  green: |
+    ifOperStatus == "up" and ifAdminStatus == "up"
+
   # SNMP target configuration
   target:
     host: 192.168.1.254
-    community: public
+    port: 161 # optional, defaults to 161
+    version: 2 # optional, defaults to 2 (1, 2, or 3)
+    community: public # for SNMP v1/v2c
+    # For SNMP v3:
+    # username: myuser
+    # auth_protocol: SHA  # optional
+    # auth_password: myauthpass  # optional
+    # privacy_protocol: AES  # optional
+    # privacy_password: myprivpass  # optional
+    bulk: true # optional, defaults to true
 ```
 
 ## Parameters
 
 ### Required Parameters
 
-- **`id`**: The monitor ID pattern using interpolation
-- **`interval`**: How often to perform SNMP queries
-- **`timeout`**: SNMP query timeout
-- **`target.host`**: The IP address or hostname of the SNMP device
-- **`target.community`**: The SNMP community string
+| Parameter | Description |
+|-----------|-------------|
+| `id` | The monitor ID pattern using interpolation with `{{ index }}` |
+| `interval` | How often to perform SNMP queries |
+| `timeout` | SNMP query timeout |
+| `target.host` | The IP address or hostname of the SNMP device |
 
 ### Optional Parameters
 
-- **`exclude`**: A filter expression to exclude certain SNMP objects
-- **`red`**: A condition that determines when the monitor should show red status
-- **`yellow`**: A condition that determines when the monitor should show yellow status
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `include` | A filter expression to include certain SNMP interfaces | `"true"` |
+| `exclude` | A filter expression to exclude certain SNMP interfaces | `"false"` |
+| `red` | A condition that determines when the monitor should show red status | `"false"` |
+| `green` | A condition that determines when the monitor should show green status | `"ifOperStatus == 'up' and ifAdminStatus == 'up'"` |
+| `target.port` | SNMP port | `161` |
+| `target.version` | SNMP version (1, 2, or 3) | `2` |
+| `target.community` | SNMP community string (for v1/v2c) | `"public"` |
+| `target.username` | SNMP username (for v3) | - |
+| `target.auth_protocol` | Authentication protocol (SHA, MD5, etc.) | - |
+| `target.auth_password` | Authentication password | - |
+| `target.privacy_protocol` | Privacy protocol (AES, DES, etc.) | - |
+| `target.privacy_password` | Privacy password | - |
+| `target.bulk` | Use bulk SNMP operations | `true` |
 
 ## Example
 
@@ -67,6 +131,7 @@ snmp:
 ```
 
 This monitor will:
+
 - Query the switch at 192.168.1.254 every 60 seconds
 - Only monitor Ethernet interfaces (exclude other interface types)
 - Show red status if an interface is up but running at less than 1Gbps
@@ -74,34 +139,57 @@ This monitor will:
 
 ## SNMP OIDs
 
-The SNMP monitor automatically queries common SNMP OIDs for network interfaces:
+The SNMP monitor automatically queries the SMTP `ifTable` table, and makes the
+OIDs available in expressions. The most useful ones you might want to use are:
 
-- **Interface Status**: `ifOperStatus`
-- **Interface Type**: `ifType`
-- **Interface Speed**: `ifSpeed`
-- **Interface Description**: `ifDescr`
-- **Interface Name**: `ifName`
+| Field            | OID/Variable    | Description                                                                                       |
+| ---------------- | --------------- | ------------------------------------------------------------------------------------------------- |
+| Status           | `ifOperStatus`  | Operational status of interface (`up` or `down`, ie: copper connected, fiber connected, etc.)     |
+| Admin Status     | `ifAdminStatus` | Administrative status of interface (`up` or `down`, ie: enabled or disabled by the administrator) |
+| Type             | `ifType`        | Type of interface (`ethernetCsmacd`, `loopback`, `other`, etc.)                                   |
+| Speed            | `ifSpeed`       | Speed of interface                                                                                |
+| Description      | `ifDescr`       | Description of interface                                                                          |
+| Name             | `ifName`        | Name of interface                                                                                 |
+| Alias            | `ifAlias`       | Alias of interface                                                                                |
+| MTU              | `ifMtu`         | Maximum Transmission Unit                                                                         |
+| Physical Address | `ifPhysAddress` | Physical (MAC) address                                                                            |
 
-## Status Conditions
+You can see the OIDs available in the `ifTable` table on your specific device
+with the `snmptable` command:
 
-You can define custom conditions for different status colors:
+```
+# Print the headers of the ifTable table
+snmptable -Ch -v 2c -c public 192.168.1.1 ifTable | head -1
+```
+
+## SNMP Versions
+
+The SNMP monitor supports SNMP v1, v2c, and v3. The default is to use v2c with
+the `public` community string. Bulk operations are enabled by default, but can
+be disabled for older devices.
+
+### SNMP v1/v2c
 
 ```yaml
 snmp:
   # ... other configuration ...
-  
-  # Show red when interface is down
-  red: |
-    ifOperStatus == "down"
-  
-  # Show yellow when interface speed is below 1Gbps
-  yellow: |
-    ifOperStatus == "up" and ifSpeed < 1000000000
+  target:
+    host: 192.168.1.254
+    version: 2 # or 1
+    community: public
 ```
 
-## Security Considerations
+### SNMP v3
 
-- Use SNMPv3 with authentication when possible
-- Avoid using the default "public" community string in production
-- Consider using SNMP communities with read-only access
-- Restrict SNMP access to specific IP addresses on your network devices
+```yaml
+snmp:
+  # ... other configuration ...
+  target:
+    host: 192.168.1.254
+    version: 3
+    username: myuser
+    auth_protocol: SHA
+    auth_password: myauthpass
+    privacy_protocol: AES
+    privacy_password: myprivpass
+```

--- a/docs/src/configuration/monitor/snmp.md
+++ b/docs/src/configuration/monitor/snmp.md
@@ -1,0 +1,107 @@
+# SNMP Monitor
+
+SNMP monitors allow you to monitor network devices using the Simple Network Management Protocol (SNMP). This is particularly useful for monitoring switches, routers, and other network infrastructure.
+
+The SNMP monitor works like a [group monitor](group.md), but it uses SNMP to
+query the network device and create children for each detected interface.
+
+## Configuration
+
+```yaml
+snmp:
+  # The ID pattern for this monitor. Uses interpolation from axis values.
+  id: router-{{ index }}
+  
+  # How often the SNMP queries are performed
+  interval: 60s
+  
+  # How long to wait for SNMP responses
+  timeout: 30s
+  
+  # (optional) Filter to exclude certain interfaces or components
+  exclude: |
+    ifType != 'ethernetCsmacd'
+  
+  # (optional) Condition that determines when the monitor should be red
+  red: |
+    ifOperStatus == "up" and ifSpeed < 1000000000
+  
+  # SNMP target configuration
+  target:
+    host: 192.168.1.254
+    community: public
+```
+
+## Parameters
+
+### Required Parameters
+
+- **`id`**: The monitor ID pattern using interpolation
+- **`interval`**: How often to perform SNMP queries
+- **`timeout`**: SNMP query timeout
+- **`target.host`**: The IP address or hostname of the SNMP device
+- **`target.community`**: The SNMP community string
+
+### Optional Parameters
+
+- **`exclude`**: A filter expression to exclude certain SNMP objects
+- **`red`**: A condition that determines when the monitor should show red status
+- **`yellow`**: A condition that determines when the monitor should show yellow status
+
+## Example
+
+Here's a complete example of an SNMP monitor for a network switch:
+
+```yaml
+snmp:
+  id: switch-{{ index }}
+  interval: 60s
+  timeout: 30s
+  exclude: |
+    ifType != 'ethernetCsmacd'
+  red: |
+    ifOperStatus == "up" and ifSpeed < 1000000000
+  target:
+    host: 192.168.1.254
+    community: public
+```
+
+This monitor will:
+- Query the switch at 192.168.1.254 every 60 seconds
+- Only monitor Ethernet interfaces (exclude other interface types)
+- Show red status if an interface is up but running at less than 1Gbps
+- Use the "public" community string for SNMP authentication
+
+## SNMP OIDs
+
+The SNMP monitor automatically queries common SNMP OIDs for network interfaces:
+
+- **Interface Status**: `ifOperStatus`
+- **Interface Type**: `ifType`
+- **Interface Speed**: `ifSpeed`
+- **Interface Description**: `ifDescr`
+- **Interface Name**: `ifName`
+
+## Status Conditions
+
+You can define custom conditions for different status colors:
+
+```yaml
+snmp:
+  # ... other configuration ...
+  
+  # Show red when interface is down
+  red: |
+    ifOperStatus == "down"
+  
+  # Show yellow when interface speed is below 1Gbps
+  yellow: |
+    ifOperStatus == "up" and ifSpeed < 1000000000
+```
+
+## Security Considerations
+
+- Use SNMPv3 with authentication when possible
+- Avoid using the default "public" community string in production
+- Consider using SNMP communities with read-only access
+- Restrict SNMP access to specific IP addresses on your network devices

--- a/docs/src/configuration/monitor/standard.md
+++ b/docs/src/configuration/monitor/standard.md
@@ -1,0 +1,48 @@
+# Standard Monitor
+
+A standard monitor consists of a single test for a single host. This is the most common type of monitor in Stylus.
+
+## Configuration
+
+```yaml
+test:
+  # (optional) The internal ID to use for this test. If omitted, the ID is inferred from the monitor directory's name.
+  id: foo
+  # How often the test is run. The interval restarts from the last success or failure of the test.
+  interval: 60s
+  # How long the script will be given to run before it is killed.
+  timeout: 30s
+  # The test command to run, relative to the monitor directory. The PATH is not used and the file must be
+  # directly executable.
+  command: test.sh
+```
+
+## Example
+
+Here's a simple example of a standard monitor that pings a host:
+
+```yaml
+test:
+  id: web-server-ping
+  interval: 30s
+  timeout: 10s
+  command: ping.sh
+```
+
+With a corresponding `ping.sh` script:
+
+```bash
+#!/bin/bash
+ping -c 1 -W 5 example.com > /dev/null 2>&1
+exit $?
+```
+
+## Environment Variables
+
+**Stylus** invokes all test scripts with a special environment variable named `STYLUS_MONITOR_ID`. This may be used
+as a convenient way to test multiple monitors using shared scripts. For example, a test script may be configured 
+like so:
+
+```bash
+ssh $STYLUS_MONITOR_ID my-test-command
+```

--- a/docs/src/examples/snmp/README.md
+++ b/docs/src/examples/snmp/README.md
@@ -1,13 +1,30 @@
 # SNMP Monitoring
 
+SNMP (Simple Network Management Protocol) is a useful way to write more complex
+checks for network devices, but the output of the tools requires some massaging.
+
 Stylus has a [built-in SNMP monitor](../../configuration/monitor/snmp.md) that
 can be used to monitor network devices, but in some cases you may want to write
 a custom script to monitor SNMP devices for more complex checks.
 
-SNMP (Simple Network Management Protocol) is a useful way to write more complex
-checks for network devices, but the output of the tools requires some massaging.
-
 ## Basic SNMP Check
+
+This performs a simple SNMP "ping" to the device, asking for its `sysDescr` and
+`sysUpTime` OIDs (system description and uptime respectively).
+
+```bash
+#!/bin/sh
+set -xeuf -o pipefail
+# Print the SNMP OID for the system description
+snmpwalk -v 2c -c public my-network-router 1.3.6.1.2.1.1.1.0
+# Print the SNMP OID for the system uptime
+snmpwalk -v 2c -c public my-network-router 1.3.6.1.2.1.1.3.0
+```
+
+## SNMP Group Monitor
+
+You can use a [group monitor](../../configuration/monitor/group.md) to monitor
+multiple devices at once using SNMP.
 
 ```bash
 snmp_check () {

--- a/docs/src/examples/snmp/README.md
+++ b/docs/src/examples/snmp/README.md
@@ -1,6 +1,11 @@
 # SNMP Monitoring
 
-SNMP (Simple Network Management Protocol) is a useful way to write more complex checks for network devices, but the output of the tools requires some massaging.
+Stylus has a [built-in SNMP monitor](../../configuration/monitor/snmp.md) that
+can be used to monitor network devices, but in some cases you may want to write
+a custom script to monitor SNMP devices for more complex checks.
+
+SNMP (Simple Network Management Protocol) is a useful way to write more complex
+checks for network devices, but the output of the tools requires some massaging.
 
 ## Basic SNMP Check
 

--- a/docs/src/getting-started/creating-monitors.md
+++ b/docs/src/getting-started/creating-monitors.md
@@ -128,11 +128,11 @@ if [ "$STATUS" != "OK" ]; then
 fi
 ```
 
-If you want to monitor network devices, you can often use
-[SNMP](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) to
-extract information from the device. SNMP allows you to query the device for
-information about its status using OIDs (Object Identifiers), which are roughly
-standardized across different devices.
+If you want to monitor network devices, you can often use the [SNMP](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) protocol.
+
+**Stylus** has a [built-in SNMP monitor](../configuration/monitor/snmp.md) that
+can be used to monitor network devices, but in some cases you may want to write
+a custom script to monitor SNMP devices for more complex checks.
 
 See the manual for your networking device for the appropriate OIDs to use, or
 reference one of the following resources: 

--- a/examples/snmp/config.yaml
+++ b/examples/snmp/config.yaml
@@ -1,0 +1,29 @@
+version: 1
+server:
+  port: 8000
+
+monitor:
+  dir: monitor.d
+
+ui:
+  title: "SNMP Status"
+  description: "SNMP Status"
+  visualizations:
+    - title: "SNMP Status"
+      description: "Current status of all SNMP components"
+      type: "table"
+    - title: "Rack 1"
+      description: "Rack 1"
+      type: "stack"
+      stacks:
+        - title: "Rack 1"
+          rows:
+            - id: "router"
+              size: "small"
+              layout: 3x1 4x2
+            - id: "switch"
+              size: "small"
+              layout: 3x4x2 1
+            - id: "switch-core"
+              size: "small"
+              layout: 3x4x2 2x2

--- a/examples/snmp/monitor.d/router/config.yaml
+++ b/examples/snmp/monitor.d/router/config.yaml
@@ -1,0 +1,19 @@
+snmp:
+  id: router-{{ index }}
+  interval: 60s
+  timeout: 30s
+  exclude: |
+    ifType != 'ethernetCsmacd'
+  # Dream Machine Pro SE names normal ports as eth<n> and
+  # the SFP/2.5G ports with branding
+  include: |
+    (startswith(ifDescr, 'eth') and not contains(ifDescr, '.'))
+      or contains(ifDescr, "10G Ethernet Adapter")
+      or contains(ifDescr, "2.5GbE Controller")
+  # SNMP doesn't work properly on the UDM Pro SE, so try to detect if the port is up
+  # via ifInOctets and ifOutOctets
+  green: |
+    ifOperStatus == "up" and ifAdminStatus == "up" and ifOutOctets > 0 and ifInOctets > 0
+  target:
+    host: 192.168.1.1
+    community: public

--- a/examples/snmp/monitor.d/switch-core/config.yaml
+++ b/examples/snmp/monitor.d/switch-core/config.yaml
@@ -1,0 +1,12 @@
+snmp:
+  id: router-{{ index }}
+  interval: 120s
+  # This device is slow to enumerate SNMP interfaces, so we need to increase the timeout
+  timeout: 60s
+  exclude: |
+    ifType != 'ethernetCsmacd'
+  red: |
+    ifOperStatus == "up" and ifSpeed < 1000000000
+  target:
+    host: 192.168.1.2
+    community: public

--- a/examples/snmp/monitor.d/switch/config.yaml
+++ b/examples/snmp/monitor.d/switch/config.yaml
@@ -1,0 +1,11 @@
+snmp:
+  id: router-{{ index }}
+  interval: 60s
+  timeout: 30s
+  exclude: |
+    ifType != 'ethernetCsmacd'
+  red: |
+    ifOperStatus == "up" and ifSpeed < 1000000000
+  target:
+    host: 192.168.1.254
+    community: public


### PR DESCRIPTION
Implements an SNMP monitor that automates most of the work to fetch SNMP status:

```yaml
snmp:
  id: router-{{ index }}
  interval: 60s
  timeout: 30s
  exclude: |
    ifType != 'ethernetCsmacd'
  red: |
    ifOperStatus == "up" and ifSpeed < 1000000000
  target:
    host: 192.168.1.254
    community: public
```

More complex example:

```yaml
snmp:
  id: router-{{ index }}
  interval: 60s
  timeout: 30s
  exclude: |
    ifType != 'ethernetCsmacd'
  # Dream Machine Pro SE names normal ports as eth<n> and the SFP/2.5G ports
  # with branding
  include: |
    (startswith(ifDescr, 'eth') and not contains(ifDescr, '.'))
      or contains(ifDescr, "10G Ethernet Adapter")
      or contains(ifDescr, "2.5GbE Controller")
  # SNMP doesn't work properly on the UDM Pro SE, so try to detect if the port
  # is up via ifInOctets and ifOutOctets
  green: |
    ifOperStatus == "up" and ifAdminStatus == "up" and ifOutOctets > 0 and ifInOctets > 0
  target:
    host: 192.168.1.1
    community: public
```
